### PR TITLE
Implementation dynamic color and dynamic textbox count

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.implementation
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -46,4 +48,5 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     implementation(project(":cipherotp"))
+   // implementation("com.github.ssk-karna:winebytes-cipherotp:1.0.0")
 }

--- a/app/src/main/java/com/winebytes/winebytesapps/MainActivity.kt
+++ b/app/src/main/java/com/winebytes/winebytesapps/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.winebytes.winebytesapps
 
 import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -19,8 +21,18 @@ class MainActivity : AppCompatActivity() {
         }
 
         val otpBoxView = findViewById<OtpBoxView>(R.id.otpBoxView)
+        val btnFetchOtp = findViewById<Button>(R.id.btn_fetch_otp)
+        val tvOtp = findViewById<TextView>(R.id.tv_otp)
         otpBoxView.setBorderColor(R.color.green)
         otpBoxView.setOtpBoxCount(6)
+
+        btnFetchOtp.setOnClickListener {
+            val otp = otpBoxView.getOtp()
+            tvOtp.setText(otp)
+            // Handle the OTP value as needed
+        }
+
+
     }
 
 }

--- a/app/src/main/java/com/winebytes/winebytesapps/MainActivity.kt
+++ b/app/src/main/java/com/winebytes/winebytesapps/MainActivity.kt
@@ -20,7 +20,7 @@ class MainActivity : AppCompatActivity() {
 
         val otpBoxView = findViewById<OtpBoxView>(R.id.otpBoxView)
         otpBoxView.setBorderColor(R.color.green)
-       // otpBoxView.setOtpBoxCount(6)
+        otpBoxView.setOtpBoxCount(6)
     }
 
 }

--- a/app/src/main/java/com/winebytes/winebytesapps/MainActivity.kt
+++ b/app/src/main/java/com/winebytes/winebytesapps/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.winebytes.cipherotp.OtpBoxView;
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,6 +18,9 @@ class MainActivity : AppCompatActivity() {
             insets
         }
 
+        val otpBoxView = findViewById<OtpBoxView>(R.id.otpBoxView)
+        otpBoxView.setBorderColor(R.color.green)
+       // otpBoxView.setOtpBoxCount(6)
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,24 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_margin="16dp" />
+    <Button
+        android:id="@+id/btn_fetch_otp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="fetch otp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/otpBoxView" />
+
+    <TextView
+        android:id="@+id/tv_otp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_fetch_otp" />
 
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,6 +17,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
     <com.winebytes.cipherotp.OtpBoxView
         android:id="@+id/otpBoxView"
         android:layout_width="wrap_content"
@@ -25,6 +26,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_margin="16dp" />
+
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="green">#5CE65C</color>
 </resources>

--- a/cipherotp/src/main/java/com/winebytes/cipherotp/OtpBoxView.kt
+++ b/cipherotp/src/main/java/com/winebytes/cipherotp/OtpBoxView.kt
@@ -17,12 +17,14 @@ import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import android.util.TypedValue
+import com.winebytes.cipherotp.utils.Constants
+import com.winebytes.cipherotp.utils.Extensions.Companion.dpToPx
 
 
 class OtpBoxView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : LinearLayout(context, attrs) {
-    private var otpLength = 4 // Default length
+    private var otpLength = Constants.MAX_OTP_LENGTH// Default length
     private val boxes = mutableListOf<EditText>()
     private var borderColor: Int = Color.BLACK // default
 
@@ -114,10 +116,6 @@ class OtpBoxView @JvmOverloads constructor(
         invalidate()  // To force a redraw with the new border color
     }
 
-
-
-    fun Int.dpToPx(context: Context): Int = (this * context.resources.displayMetrics.density).toInt()
-
     fun getOtp(): String = boxes.joinToString("") { it.text.toString() }
     fun setOtp(value: String) {
         value.forEachIndexed { index, char ->
@@ -126,7 +124,7 @@ class OtpBoxView @JvmOverloads constructor(
     }
 
     // Expose a setter method to change the number of OTP boxes programmatically
-    fun setOtpBoxCount(@IntRange(from = 4, to = 8) count: Int = 4) { // Ensure it's between 4 and 8
+    fun setOtpBoxCount(@IntRange(from = Constants.MIN_OTP_LENGTH.toLong(), to = Constants.MAX_OTP_LENGTH.toLong()) count: Int = Constants.MIN_OTP_LENGTH) { // Ensure it's between 4 and 8
         otpLength = count
         setupOtpBoxes()  // Rebuild the boxes with the new count
     }

--- a/cipherotp/src/main/java/com/winebytes/cipherotp/OtpBoxView.kt
+++ b/cipherotp/src/main/java/com/winebytes/cipherotp/OtpBoxView.kt
@@ -1,7 +1,7 @@
 package com.winebytes.cipherotp
 
 import android.content.Context
-import android.graphics.Canvas
+import androidx.annotation.IntRange
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.drawable.Drawable
@@ -124,6 +124,13 @@ class OtpBoxView @JvmOverloads constructor(
             if (index < boxes.size) boxes[index].setText(char.toString())
         }
     }
+
+    // Expose a setter method to change the number of OTP boxes programmatically
+    fun setOtpBoxCount(@IntRange(from = 4, to = 8) count: Int = 4) { // Ensure it's between 4 and 8
+        otpLength = count
+        setupOtpBoxes()  // Rebuild the boxes with the new count
+    }
+
 
     private fun getOtpTextWatcher(index: Int): TextWatcher {
         return object : TextWatcher {

--- a/cipherotp/src/main/java/com/winebytes/cipherotp/utils/Constants.kt
+++ b/cipherotp/src/main/java/com/winebytes/cipherotp/utils/Constants.kt
@@ -1,0 +1,15 @@
+package com.winebytes.cipherotp.utils
+
+class Constants {
+
+    companion object{
+        const val MIN_OTP_LENGTH = 4
+        const val MAX_OTP_LENGTH = 8
+        const val DEFAULT_BORDER_COLOR = "#000000"
+        const val DEFAULT_BOX_BACKGROUND_COLOR = "#FFFFFF"
+        const val DEFAULT_BOX_TEXT_COLOR = "#000000"
+        const val DEFAULT_BOX_BORDER_WIDTH = 2
+        const val DEFAULT_BOX_RADIUS = 8
+        const val DEFAULT_BOX_MARGIN = 4
+    }
+}

--- a/cipherotp/src/main/java/com/winebytes/cipherotp/utils/Extensions.kt
+++ b/cipherotp/src/main/java/com/winebytes/cipherotp/utils/Extensions.kt
@@ -1,0 +1,11 @@
+package com.winebytes.cipherotp.utils
+
+import android.content.Context
+
+class Extensions {
+
+    companion object {
+        fun Int.dpToPx(context: Context): Int = (this * context.resources.displayMetrics.density).toInt()
+
+    }
+}

--- a/cipherotp/src/main/res/values/attrs.xml
+++ b/cipherotp/src/main/res/values/attrs.xml
@@ -1,0 +1,5 @@
+<resources>
+    <declare-styleable name="OtpBoxView">
+        <attr name="boxBorderColor" format="color" />
+    </declare-styleable>
+</resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,9 @@ pluginManagement {
             }
         }
         mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+        }
         gradlePluginPortal()
     }
 }
@@ -16,6 +19,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+        }
     }
 }
 


### PR DESCRIPTION
I ntegration of OtpBoxView Component:  
Added a custom OtpBoxView component in the cipherotp module.
The OtpBoxView allows users to input OTP codes with customizable box count, border color, and other visual properties.

Key Feature

Customizable OTP box count (default: 4, range: 4-8).
Ability to set border color dynamically.
Smooth navigation between boxes as the user types.
Input validation and focus handling for seamless user experience.